### PR TITLE
Add auto_autoloader to  runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     stripe_model_callbacks (0.1.2)
+      auto_autoloader
       money-rails
       public_activity
       rails (>= 5.0.0)

--- a/stripe_model_callbacks.gemspec
+++ b/stripe_model_callbacks.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 5.0.0"
+  s.add_runtime_dependency "auto_autoloader"
   s.add_runtime_dependency "money-rails"
   s.add_runtime_dependency "public_activity"
   s.add_runtime_dependency "service_pattern"


### PR DESCRIPTION
`auto_autoloader` is still required.

https://github.com/kaspernj/stripe_model_callbacks/blob/b61efa7d302371e030bc90bb26a3cc834f222612/lib/stripe_model_callbacks.rb#L1